### PR TITLE
CellSet axes consuming too much memory

### DIFF
--- a/lib/olap4r/cellset.rb
+++ b/lib/olap4r/cellset.rb
@@ -15,7 +15,7 @@ module Olap
               members << {
                 :name => member.get_caption,
                 :unique_name => member.get_unique_name,
-                :drillable => member.get_child_members.size > 0
+                :drillable => member.get_child_member_count > 0
               }
             end
           end


### PR DESCRIPTION
Pulling the entire array of child members to calculate length is unnecessary and can cause java to run out of heap for high cardinality.  Using http://www.olap4j.org/api/org/olap4j/metadata/Member.html#getChildMemberCount() instead.
